### PR TITLE
fix: `lint` 테스크에 컴포넌트 빌드 추가

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,11 @@
       "outputs": ["dist/**"]
     },
     "lint": {
-      "dependsOn": ["^lint", "@passu/ui#build:styles"]
+      "dependsOn": [
+        "^lint",
+        "@passu/ui#build:styles",
+        "@passu/ui#build:components"
+      ]
     },
     "check-types": {
       "dependsOn": ["^check-types"]


### PR DESCRIPTION
- `lint` 테스크에 컴포넌트 빌드를 추가하여 ui 컴포넌트 사용시 CI 오류를 해결합니다.