### PR TITLE
feat(user): 이벤트 카드 상태별 정렬 기능 추가

### DIFF
--- a/apps/user/src/routes/index.tsx
+++ b/apps/user/src/routes/index.tsx
@@ -13,8 +13,21 @@ export const Route = createFileRoute("/")({
   component: App,
 });
 
+const EVENT_STATUS_ORDER: Record<EventInfoData["status"], number> = {
+  ONGOING: 0, // 행사 중
+  PAUSE: 1, // 일시 정지
+  BEFORE: 2, // 시작 전
+  AFTER: 3, // 종료
+};
+
 function filterTodayEvents(events: EventInfoData[]): EventInfoData[] {
   return events.filter((event) => isToday(event.start_time));
+}
+
+function sortEventsByStatus(events: EventInfoData[]): EventInfoData[] {
+  return [...events].sort(
+    (a, b) => EVENT_STATUS_ORDER[a.status] - EVENT_STATUS_ORDER[b.status],
+  );
 }
 
 function EventCardSkeleton() {
@@ -53,7 +66,10 @@ function App() {
   const isLoggedIn = userInfo?.result === true;
 
   const todayEvents = useMemo(
-    () => (data?.result && data.data ? filterTodayEvents(data.data) : []),
+    () =>
+      data?.result && data.data
+        ? sortEventsByStatus(filterTodayEvents(data.data))
+        : [],
     [data],
   );
 


### PR DESCRIPTION
## 개요
오늘의 행사 목록에서 이벤트 카드를 상태별로 정렬하여 사용자 경험을 개선합니다.

## 변경 사항
- 이벤트 상태별 정렬 우선순위 정의 (`EVENT_STATUS_ORDER`)
  - ONGOING (진행 중): 0
  - PAUSE (일시 정지): 1  
  - BEFORE (시작 전): 2
  - AFTER (종료): 3
- `sortEventsByStatus` 함수 추가
- 오늘의 행사 목록에 정렬 로직 적용

## 테스트
- [x] 오늘의 행사 목록에서 진행 중인 행사가 상단에 표시되는지 확인
- [x] 종료된 행사가 하단에 표시되는지 확인